### PR TITLE
Removed deprecated `bottle :unneeded`

### DIFF
--- a/Formula/xhdmi-tools.rb
+++ b/Formula/xhdmi-tools.rb
@@ -6,7 +6,6 @@ class XhdmiTools < Formula
   desc "XHDMI-Tools, e.g. for creating custom fonts and gamma/color maps"
   homepage "https://gitlab.com/chriz2600/xhdmi-tools"
   version "1.8.6"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Fix for `brew update` warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the chriz2600/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/chriz2600/homebrew-tap/Formula/xhdmi-tools.rb:9
```